### PR TITLE
Update Kotlin and dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.molo17.couchbase.lite"
-        minSdkVersion 22
-        targetSdkVersion 31
+        minSdk 22
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -42,23 +41,22 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation libraries.kotlin
     implementation libraries.coroutines
-    implementation "com.couchbase.lite:couchbase-lite-android:2.7.0"
+    implementation "com.couchbase.lite:couchbase-lite-android:3.0.5"
 
-    implementation project(":kotlin")
+    implementation project(":android-ktx")
 
-    implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation "androidx.core:core-ktx:1.2.0"
-    implementation "androidx.activity:activity-ktx:1.1.0"
-    implementation "androidx.recyclerview:recyclerview:1.1.0"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+    implementation "androidx.appcompat:appcompat:1.6.0"
+    implementation "androidx.core:core-ktx:1.9.0"
+    implementation "androidx.activity:activity-ktx:1.6.1"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "com.github.bumptech.glide:glide:4.11.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation "com.github.bumptech.glide:glide:4.14.2"
 
     testImplementation libraries.unitTests
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
-        <activity android:name=".MainActivity" android:exported="false">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/molo17/couchbase/lite/DependencyContainer.kt
+++ b/app/src/main/java/com/molo17/couchbase/lite/DependencyContainer.kt
@@ -25,6 +25,7 @@ import com.couchbase.lite.DatabaseConfiguration
 import com.couchbase.lite.Replicator
 import com.couchbase.lite.ReplicatorConfiguration
 import com.couchbase.lite.URLEndpoint
+import com.molo17.couchbase.lite.android.ktx.bindToLifecycle
 import com.molo17.couchbase.lite.data.CouchbaseHotelRepository
 import com.molo17.couchbase.lite.domain.HotelsRepository
 import java.net.URI
@@ -40,7 +41,7 @@ object DependencyContainer : ViewModelProvider.Factory {
 
     operator fun invoke(): () -> ViewModelProvider.Factory = { this }
 
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return when (modelClass) {
             MainViewModel::class.java -> MainViewModel(hotelsRepository)
             else -> error("${modelClass.simpleName} not handled in DependencyContainer")
@@ -61,9 +62,10 @@ object DependencyContainer : ViewModelProvider.Factory {
 
     private val replicator by lazy {
         val url = URLEndpoint(URI.create(BuildConfig.REPLICATOR_URL))
-        val config = ReplicatorConfiguration(database, url).apply {
-            authenticator = BasicAuthenticator(BuildConfig.REPLICATOR_USER, BuildConfig.REPLICATOR_PWD)
-        }
+        val config = ReplicatorConfiguration(database, url)
+            .setAuthenticator(
+                BasicAuthenticator(BuildConfig.REPLICATOR_USER, BuildConfig.REPLICATOR_PWD.toCharArray())
+            )
         Replicator(config)
     }
 }

--- a/app/src/main/java/com/molo17/couchbase/lite/MainActivity.kt
+++ b/app/src/main/java/com/molo17/couchbase/lite/MainActivity.kt
@@ -30,7 +30,7 @@ import com.molo17.couchbase.lite.domain.Hotel
  */
 class MainActivity : AppCompatActivity() {
 
-    private val viewModel by viewModels<MainViewModel>(DependencyContainer())
+    private val viewModel by viewModels<MainViewModel>(factoryProducer = DependencyContainer())
     private lateinit var views: ActivityMainBinding
 
     private val adapter by lazy { HotelsAdapter() }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,11 +24,10 @@ allprojects {
 
 ext {
     libraries = [
-        kotlin: "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version",
-        coroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0",
-        lifecycle: "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0",
+        coroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4",
+        lifecycle: "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1",
         unitTests: "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
-        mockito: "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+        mockito: "org.mockito.kotlin:mockito-kotlin:4.1.0"
     ]
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/library-android/build.gradle
+++ b/library-android/build.gradle
@@ -5,11 +5,10 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
-        minSdk 21
-        targetSdk 31
+        minSdk 22
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -31,9 +30,8 @@ android {
 }
 
 dependencies {
-    def couchbaseLite = "com.couchbase.lite:couchbase-lite-android-ktx:3.0.0"
+    def couchbaseLite = "com.couchbase.lite:couchbase-lite-android-ktx:3.0.5"
 
-    implementation libraries.kotlin
     implementation libraries.coroutines
     compileOnly libraries.lifecycle
     compileOnly couchbaseLite

--- a/library-android/src/main/java/com/molo17/couchbase/lite/android/ktx/QueryExtensions.kt
+++ b/library-android/src/main/java/com/molo17/couchbase/lite/android/ktx/QueryExtensions.kt
@@ -20,6 +20,7 @@ import com.couchbase.lite.*
 import com.molo17.couchbase.lite.mapToObjects
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
 
 /**
  * Returns a [Flow] that emits the Query [ResultSet] every time the underlying
@@ -27,7 +28,10 @@ import kotlinx.coroutines.flow.mapNotNull
  *
  * If the query fails, the [Flow] throws an error.
  */
-fun Query.asKtxFlow(): Flow<ResultSet> = queryChangeFlow().mapNotNull { it.results }
+fun Query.asKtxFlow(): Flow<ResultSet> =
+    queryChangeFlow()
+        .onEach { it.error?.let { error -> throw error } }
+        .mapNotNull { it.results }
 
 /**
  * Returns a [Flow] that maps the Query [ResultSet] to instances of a class

--- a/library-android/src/main/java/com/molo17/couchbase/lite/android/ktx/ReplicatorExtensions.kt
+++ b/library-android/src/main/java/com/molo17/couchbase/lite/android/ktx/ReplicatorExtensions.kt
@@ -1,0 +1,39 @@
+package com.molo17.couchbase.lite.android.ktx
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.couchbase.lite.Replicator
+
+/**
+ * Binds the [Replicator] instance to the given [Lifecycle].
+ *
+ * The replicator will be automatically started on the ON_RESUME event,
+ * and stopped on the ON_PAUSE event.
+ *
+ * @see Lifecycle
+ * @see Lifecycle.Event.ON_RESUME
+ * @see Lifecycle.Event.ON_PAUSE
+ */
+fun Replicator.bindToLifecycle(lifecycle: Lifecycle) {
+    lifecycle.addObserver(ReplicatorLifecycleObserver(this))
+}
+
+/**
+ * Provides a binding between the Android lifecycle and the Replicator lifecycle.
+ *
+ * The replicator will be automatically started on the ON_RESUME event,
+ * and stopped on the ON_PAUSE event.
+ */
+internal class ReplicatorLifecycleObserver(
+    private val replicator: Replicator
+) : LifecycleEventObserver {
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_RESUME -> replicator.start()
+            Lifecycle.Event.ON_PAUSE -> replicator.stop()
+            Lifecycle.Event.ON_DESTROY -> source.lifecycle.removeObserver(this)
+            else -> { } // ignored.
+        }
+    }
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,11 +2,9 @@ apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 
 dependencies {
-    def couchbaseLite = "com.couchbase.lite:couchbase-lite-java:3.0.0"
+    def couchbaseLite = "com.couchbase.lite:couchbase-lite-java:3.0.5"
 
-    implementation libraries.kotlin
     implementation libraries.coroutines
-    compileOnly libraries.lifecycle
     compileOnly couchbaseLite
 
     testImplementation libraries.unitTests

--- a/library/src/main/java/com/molo17/couchbase/lite/ReplicatorExtensions.kt
+++ b/library/src/main/java/com/molo17/couchbase/lite/ReplicatorExtensions.kt
@@ -16,14 +16,10 @@
 
 package com.molo17.couchbase.lite
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
 import com.couchbase.lite.DocumentReplication
 import com.couchbase.lite.Replicator
 import com.couchbase.lite.ReplicatorChange
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -46,37 +42,4 @@ fun Replicator.changesFlow(): Flow<ReplicatorChange> = callbackFlow {
 fun Replicator.documentReplicationFlow(): Flow<DocumentReplication> = callbackFlow {
     val token = addDocumentReplicationListener { replication -> trySendBlocking(replication) }
     awaitClose { removeChangeListener(token) }
-}
-
-/**
- * Binds the [Replicator] instance to the given [Lifecycle].
- *
- * The replicator will be automatically started on the ON_RESUME event,
- * and stopped on the ON_PAUSE event.
- *
- * @see Lifecycle
- * @see Lifecycle.Event.ON_RESUME
- * @see Lifecycle.Event.ON_PAUSE
- */
-fun Replicator.bindToLifecycle(lifecycle: Lifecycle) {
-    lifecycle.addObserver(ReplicatorLifecycleObserver(this))
-}
-
-/**
- * Provides a binding between the Android lifecycle and the Replicator lifecycle.
- *
- * The replicator will be automatically started on the ON_RESUME event,
- * and stopped on the ON_PAUSE event.
- */
-internal class ReplicatorLifecycleObserver(
-    private val replicator: Replicator
-) : LifecycleEventObserver {
-    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-        when (event) {
-            Lifecycle.Event.ON_RESUME -> replicator.start()
-            Lifecycle.Event.ON_PAUSE -> replicator.stop()
-            Lifecycle.Event.ON_DESTROY -> source.lifecycle.removeObserver(this)
-            else -> { } // ignored.
-        }
-    }
 }

--- a/library/src/test/java/com/molo17/couchbase/lite/QueryExtensionsKtTest.kt
+++ b/library/src/test/java/com/molo17/couchbase/lite/QueryExtensionsKtTest.kt
@@ -21,11 +21,11 @@ import com.couchbase.lite.Query
 import com.couchbase.lite.QueryChange
 import com.couchbase.lite.QueryChangeListener
 import com.couchbase.lite.ResultSet
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first


### PR DESCRIPTION
- Update Kotlin to 1.8.0.
- Update dependencies to latest versions.
- Move replicator lifecycle extension to **android-ktx**. Fixes #8.
- Ensure `asKtxFlow()` throws errors. `asQueryFlow()` does, but `queryChangeFlow()` does not.
- Fix sample app build.